### PR TITLE
Replace icons with inline SVG and enhance global styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,31 +1,63 @@
-/* src/app/globals.css */
-@import "tailwindcss"; /* inclui preflight + utilities na v4 */
+@import "tailwindcss"; /* Tailwind v4: inclui preflight + utilities */
 
-/* ---- Tokens e tema ---- */
+/* =========================
+   Design tokens (LIGHT)
+   ========================= */
 :root{
-    --primary:#6f44ff;
-    --primary-600:#5a36e6;
-    --secondary:#43b0ff;
-    --bg:#f6f7fb;
-    --fg:#18192b;
-    --bg-dark:#161827;
-    --fg-dark:#e7ebf3;
-    --card:#ffffff;
-    --card-dark:#1e2032;
-    --shadow:0 12px 30px -12px rgba(8,12,44,.18);
+    /* Brand */
+    --primary: #6f44ff;
+    --primary-600: #5a36e6;
+    --secondary: #43b0ff;
+
+    /* Base (light) */
+    --bg: #f6f7fb;
+    --fg: #18192b;
+    --card: #ffffff;
+
+    /* Base (dark) – usados apenas por .dark */
+    --bg-dark: #161827;
+    --fg-dark: #e7ebf3;
+    --card-dark: #1e2032;
+
+    /* Effects */
+    --shadow: 0 12px 30px -12px rgba(8, 12, 44, .18);
+
+    /* Chips / badges (light) */
+    --chip-bg: #141826; /* pill mais escuro p/ contrastar no light */
+    --chip-fg: #e8ecf8; /* texto claro no light */
+    --chip-border: rgba(17, 24, 39, .22); /* borda discreta no light */
 }
 
+/* =========================
+   Overrides no modo escuro
+   ========================= */
+.dark {
+    /* Chips / badges (dark) */
+    --chip-bg: #151a2b;
+    --chip-fg: #e9edf7;
+    --chip-border: rgba(255, 255, 255, .12);
+}
+
+/* =========================
+   Base
+   ========================= */
 html{ scroll-behavior:smooth; }
 
 body{
-    background:var(--bg);
-    color:var(--fg);
+    background: var(--bg);
+    color: var(--fg);
     font-family: var(--font-geist-sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial, sans-serif);
     transition: background .35s, color .35s;
 }
-.dark body{ background:var(--bg-dark); color:var(--fg-dark); }
 
-/* ---- Utilitários reusáveis com @apply ---- */
+.dark body {
+    background: var(--bg-dark);
+    color: var(--fg-dark);
+}
+
+/* =========================
+   Utilitários
+   ========================= */
 .container-xxl{ @apply max-w-6xl mx-auto px-4 sm:px-6; }
 
 .card{
@@ -34,14 +66,42 @@ body{
     background: var(--card);
     box-shadow: var(--shadow);
 }
+
 .dark .card{ background: var(--card-dark); }
 
-.btn{ @apply inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-semibold transition; }
-.btn-primary{ background:var(--primary); color:#fff; }
-.btn-primary:hover{ background:var(--primary-600); }
+.btn {
+    @apply inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-semibold transition;
+}
+
+.btn-primary {
+    background: var(--primary);
+    color: #fff;
+}
+
+.btn-primary:hover {
+    background: var(--primary-600);
+}
 .btn-ghost{ @apply border border-black/10 dark:border-white/15 bg-transparent; }
 
-/* ===== Tema: transições suaves globais (ligadas por 500ms) ===== */
+/* =========================
+   Chips (badges) prontos
+   ========================= */
+.chip {
+    @apply inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium border;
+    background: var(--chip-bg);
+    color: var(--chip-fg);
+    border-color: var(--chip-border);
+}
+
+.chip-icon {
+    @apply inline-grid place-items-center size-7 rounded-lg;
+    background: color-mix(in oklab, var(--primary) 15%, transparent);
+    color: var(--primary);
+}
+
+/* =========================
+   Tema: transições suaves
+   ========================= */
 .theme-smooth * {
     transition:
             background-color .35s ease,
@@ -52,31 +112,21 @@ body{
             box-shadow .35s ease;
 }
 
-/* ===== Ripple radial que revela o novo tema ===== */
+/* =========================
+   Tema: ripple reveal
+   ========================= */
 .theme-ripple{
     position: fixed;
     inset: 0;
     pointer-events: none;
     z-index: 9999;
-    /* posição do clique vinda do JS */
     --x: 50%;
     --y: 50%;
-    /* usa a cor de fundo do TEMA ATUAL (já alternado) */
-    /* como o body já mudou, var(--bg) / var(--bg-dark) já refletem a cor certa */
-    background:
-            radial-gradient(circle at var(--x) var(--y),
-            var(--bg) 0,
-            var(--bg) 0,
-            transparent 0);
+    background: radial-gradient(circle at var(--x) var(--y), var(--bg) 0, var(--bg) 0, transparent 0);
     animation: theme-ripple-expand 600ms ease-out forwards;
 }
-
 .dark .theme-ripple{
-    background:
-            radial-gradient(circle at var(--x) var(--y),
-            var(--bg-dark) 0,
-            var(--bg-dark) 0,
-            transparent 0);
+    background: radial-gradient(circle at var(--x) var(--y), var(--bg-dark) 0, var(--bg-dark) 0, transparent 0);
 }
 
 @keyframes theme-ripple-expand{
@@ -84,6 +134,7 @@ body{
     100% { background-size: 200vmax 200vmax; opacity: 0; }
 }
 
+/* glow overlay durante a troca */
 #theme-overlay {
     position: fixed;
     inset: 0;
@@ -92,21 +143,8 @@ body{
     opacity: 0;
     transition: opacity .6s ease;
 }
+
 html.theme-animating #theme-overlay {
     opacity: 1;
-    background: radial-gradient(800px 800px at var(--x,50%) var(--y,50%),
-    rgba(111,68,255,.25), transparent 60%);
-}
-
-/* ---- Chips (badges) com contraste por tema ---- */
-:root {
-    --chip-bg: #141826; /* CLARO: pill escuro (contrasta no teu layout) */
-    --chip-fg: #e8ecf8; /* CLARO: texto claro */
-    --chip-border: rgba(17, 24, 39, .22); /* CLARO: borda discreta */
-}
-
-.dark {
-    --chip-bg: #151a2b; /* ESCURO: pill escuro */
-    --chip-fg: #e9edf7; /* ESCURO: texto claro */
-    --chip-border: rgba(255, 255, 255, .12);
+    background: radial-gradient(800px 800px at var(--x, 50%) var(--y, 50%), rgba(111, 68, 255, .25), transparent 60%);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
     description: "Junior Java Developer · Software Engineering Student @ ISEP",
 };
 
-export default function RootLayout({children}: { children: ReactNode }) {
+export default function RootLayout({children}: { readonly children: ReactNode }) {
     return (
         <html lang="pt" suppressHydrationWarning>
         <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -3,7 +3,7 @@ export default function About(){
         <section id="about" className="card">
             <h3 className="text-2xl font-bold mb-2">Sobre Mim</h3>
             <p className="text-[15px] leading-7">
-                Estudante de <b>Engenharia Informática</b> no <b>ISEP</b> e
+                Estudante de <b>Engenharia Informática</b> no <b>ISEP</b> e{' '}
                 <b>Junior Java Developer</b> na <b>NiW (Salvador Caetano)</b>.
                 Adoro backend, clean code e boas integrações REST.
             </p>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,4 +1,4 @@
-import { Mail, Github, Linkedin, Download } from "lucide-react";
+import {Download, Mail} from "lucide-react";
 
 export default function Contact(){
     return (
@@ -8,8 +8,26 @@ export default function Contact(){
 
             <div className="mt-6 flex flex-col sm:flex-row items-center justify-center gap-3">
                 <a href="mailto:tiago.ferraz.dev@gmail.com" className="btn btn-ghost"><Mail size={18}/> Email</a>
-                <a href="https://github.com/Ferraz5" target="_blank" className="btn btn-ghost"><Github size={18}/> GitHub</a>
-                <a href="https://www.linkedin.com/in/tiago-ferraz" target="_blank" className="btn btn-primary"><Linkedin size={18}/> LinkedIn</a>
+                <a href="https://github.com/Ferraz5" target="_blank" className="btn btn-ghost" aria-label="GitHub">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
+                         stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                         className="lucide lucide-github">
+                        <path
+                            d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 5.77a5.07 5.07 0 0 0-.09-3.86S18.73 1.56 16 3a13.38 13.38 0 0 0-7 0C6.27 1.56 5.09 1.91 5.09 1.91A5.07 5.07 0 0 0 5 5.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/>
+                    </svg>
+                    GitHub
+                </a>
+                <a href="https://www.linkedin.com/in/tiago-ferraz" target="_blank" className="btn btn-primary"
+                   aria-label="LinkedIn">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
+                         stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                         className="lucide lucide-linkedin">
+                        <path d="M16 8a6 6 0 0 1 6 6v5h-4v-5a2 2 0 0 0-2-2 2 2 0 0 0-2 2v5h-4v-5a6 6 0 0 1 6-6z"/>
+                        <rect width="4" height="12" x="2" y="9"/>
+                        <circle cx="4" cy="4" r="2"/>
+                    </svg>
+                    LinkedIn
+                </a>
                 <a href="/TiagoFerraz-CV.pdf" download className="btn btn-ghost"><Download size={18}/> Download CV</a>
             </div>
         </section>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { Github, Linkedin, Mail, Download } from "lucide-react";
+import {Download, Mail} from "lucide-react";
 import ThemeToggle from "./ThemeToggle";
 
 const nav = [
@@ -38,8 +38,26 @@ export default function Sidebar(){
 
                     <div className="mt-4 flex justify-center gap-2">
                         <a href="mailto:tiagoairesmferraz@gmail.com" className="btn btn-ghost !px-3" aria-label="Email"><Mail size={18}/></a>
-                        <a href="https://github.com/Ferraz5" target="_blank" className="btn btn-ghost !px-3" aria-label="GitHub"><Github size={18}/></a>
-                        <a href="https://www.linkedin.com/in/tiago-ferraz" target="_blank" className="btn btn-ghost !px-3" aria-label="LinkedIn"><Linkedin size={18}/></a>
+                        <a href="https://github.com/Ferraz5" target="_blank" className="btn btn-ghost !px-3"
+                           aria-label="GitHub">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
+                                 fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"
+                                 strokeLinejoin="round" className="lucide lucide-github">
+                                <path
+                                    d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 5.77a5.07 5.07 0 0 0-.09-3.86S18.73 1.56 16 3a13.38 13.38 0 0 0-7 0C6.27 1.56 5.09 1.91 5.09 1.91A5.07 5.07 0 0 0 5 5.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/>
+                            </svg>
+                        </a>
+                        <a href="https://www.linkedin.com/in/tiago-ferraz" target="_blank"
+                           className="btn btn-ghost !px-3" aria-label="LinkedIn">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
+                                 fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"
+                                 strokeLinejoin="round" className="lucide lucide-linkedin">
+                                <path
+                                    d="M16 8a6 6 0 0 1 6 6v5h-4v-5a2 2 0 0 0-2-2 2 2 0 0 0-2 2v5h-4v-5a6 6 0 0 1 6-6z"/>
+                                <rect width="4" height="12" x="2" y="9"/>
+                                <circle cx="4" cy="4" r="2"/>
+                            </svg>
+                        </a>
                     </div>
 
                     <a


### PR DESCRIPTION
This pull request includes the following changes:
- Replaced Lucide icons for GitHub and LinkedIn with inline SVG for better performance and customization.
- Enhanced global styles by incorporating detailed design tokens.
- Improved dark mode refinements for a consistent theme experience.

No additional issues were attached to this pull request.